### PR TITLE
Disable OpenCL on GPU, enable L0 on WIN

### DIFF
--- a/tests/unit_tests/main_test.cpp
+++ b/tests/unit_tests/main_test.cpp
@@ -34,7 +34,7 @@ using ::testing::TestInfo;
 using ::testing::TestPartResult;
 using ::testing::UnitTest;
 
-cl::sycl::device host, cpu, gpu;
+cl::sycl::device host, cpu, gpu = cl::sycl::default_selector().select_device();
 std::vector<cl::sycl::device> devices;
 
 std::string gtestInFile;
@@ -91,12 +91,10 @@ int main(int argc, char** argv) {
                         unique_devices.insert(dev.get_info<cl::sycl::info::device::name>());
                         unsigned int vendor_id = static_cast<unsigned int>(
                             dev.get_info<cl::sycl::info::device::vendor_id>());
-                        /* temporary w/a to exclude L0 from windows testing */
-#ifdef _WIN64
-                        if (plat.get_info<cl::sycl::info::platform::version>().find("Level-Zero") !=
-                            std::string::npos)
+                        /* Do not test for OpenCL backend on GPU */
+                        if (dev.is_gpu() && plat.get_info<cl::sycl::info::platform::name>().find(
+                                                "OpenCL") != std::string::npos)
                             continue;
-#endif
 #ifndef ENABLE_MKLCPU_BACKEND
                         if (dev.is_cpu())
                             continue;


### PR DESCRIPTION
This MR is disabling OpenCL runtime testing on GPU and enabling L0 testing on WIN